### PR TITLE
Bump the Firefox Driver extension max version to FF 26.

### DIFF
--- a/javascript/firefox-driver/extension/install.rdf
+++ b/javascript/firefox-driver/extension/install.rdf
@@ -15,7 +15,7 @@
             <Description>
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
                 <em:minVersion>3.0</em:minVersion>
-                <em:maxVersion>25.*</em:maxVersion>
+                <em:maxVersion>26.*</em:maxVersion>
             </Description>
         </em:targetApplication>
 
@@ -23,7 +23,7 @@
         <em:targetPlatform>Darwin</em:targetPlatform>
         <em:targetPlatform>SunOS</em:targetPlatform>
         <em:targetPlatform>FreeBSD</em:targetPlatform>
-        
+
         <!-- Platforms where we are -->
         <em:targetPlatform>WINNT_x86-msvc</em:targetPlatform>
         <em:targetPlatform>Linux</em:targetPlatform>


### PR DESCRIPTION
Now that FF 26 is on gecko, we need to bump the install.rdf max version.
